### PR TITLE
fix(task): Increase task priority to High [MNA-1080]

### DIFF
--- a/MODBUS-LIB/Src/Modbus.c
+++ b/MODBUS-LIB/Src/Modbus.c
@@ -48,13 +48,13 @@ const osMessageQueueAttr_t QueueTelegram_attributes = {
 
 const osThreadAttr_t myTaskModbusA_attributes = {
     .name = "TaskModbusSlave",
-    .priority = (osPriority_t) osPriorityNormal,
+    .priority = (osPriority_t) osPriorityHigh,
     .stack_size = 128 * 4
 };
 
 const osThreadAttr_t myTaskModbusA_attributesTCP = {
     .name = "TaskModbusSlave",
-    .priority = (osPriority_t) osPriorityNormal,
+    .priority = (osPriority_t) osPriorityHigh,
     .stack_size = 256 * 6
 };
 


### PR DESCRIPTION
Increasing priority of modbus task to be the highest priority task, reducing response time oscillations.